### PR TITLE
Update __init__.py

### DIFF
--- a/teng/__init__.py
+++ b/teng/__init__.py
@@ -7,7 +7,7 @@
 # AUTHOR        Michal Bukovsky <burlog@seznam.cz>
 #
 
-from collections import Iterable, Mapping
+from collections.abc import Iterable, Mapping
 
 from rawteng import Teng
 from rawteng import listSupportedContentTypes


### PR DESCRIPTION
Supress DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working